### PR TITLE
Fix dev dependencies for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,3 @@ kubectl apply -f k8s/ingress.yaml
 ```
 
 The frontend will be reachable via the ingress host `ids.212southadvisors.com`.
-=======

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+# Install all dependencies so Vite is available when running the dev server
+RUN npm install
 COPY . .
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- install all dependencies in `frontend/Dockerfile`
- cleanup stray text in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68657a5d90b8832f95b632089964073b