### PR TITLE
Fix import when running app.py directly

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,10 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_httpauth import HTTPBasicAuth
 from flask_cors import CORS
-from .models import db, Role, User, Vendor, Product, Project, ProductProject, Inventory, Client
+try:
+    from .models import db, Role, User, Vendor, Product, Project, ProductProject, Inventory, Client
+except ImportError:  # allows running as 'python app.py'
+    from models import db, Role, User, Vendor, Product, Project, ProductProject, Inventory, Client
 import os
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- allow backend/app.py to be run directly by adding try/except around models import

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68659927a138832fae1bbcd6086f9e72