### PR TITLE
Add contracts and task tracking

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,11 +3,20 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_httpauth import HTTPBasicAuth
 from flask_cors import CORS
+from googleapiclient.discovery import build
+from google.oauth2.service_account import Credentials
+import json
 
 try:
-    from .models import db, Role, User, Vendor, Product, Project, ProductProject, Inventory, Client
+    from .models import (
+        db, Role, User, Vendor, Product, Project, ProductProject, Inventory,
+        Client, Employee, LeadStage, Lead, ContractStatus, Contract, Task
+    )
 except ImportError:  # allows running as 'python app.py'
-    from models import db, Role, User, Vendor, Product, Project, ProductProject, Inventory, Client
+    from models import (
+        db, Role, User, Vendor, Product, Project, ProductProject, Inventory,
+        Client, Employee, LeadStage, Lead, ContractStatus, Contract, Task
+    )
 import os
 
 app = Flask(__name__)
@@ -18,6 +27,31 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 bcrypt = Bcrypt(app)
 auth = HTTPBasicAuth()
+
+
+def get_tasks_service():
+    creds_file = os.getenv('GOOGLE_SERVICE_ACCOUNT_FILE')
+    if not creds_file or not os.path.exists(creds_file):
+        return None
+    creds = Credentials.from_service_account_file(
+        creds_file, scopes=['https://www.googleapis.com/auth/tasks']
+    )
+    return build('tasks', 'v1', credentials=creds)
+
+
+def sync_task_to_google(task):
+    service = get_tasks_service()
+    if not service:
+        return
+    body = {'title': task.name}
+    if task.due_date:
+        body['due'] = f"{task.due_date.isoformat()}T00:00:00Z"
+    try:
+        res = service.tasks().insert(tasklist='@default', body=body).execute()
+        task.google_task_id = res.get('id')
+        db.session.commit()
+    except Exception as exc:
+        print('Google Tasks sync failed:', exc)
 
 @auth.verify_password
 def verify_password(username, password):
@@ -210,6 +244,135 @@ def list_leads():
         } for l in leads
     ])
 
+
+@app.route('/contractstatuses', methods=['GET'])
+def list_contract_statuses():
+    statuses = ContractStatus.query.all()
+    return jsonify([{'id': s.id, 'name': s.name} for s in statuses])
+
+
+@app.route('/contracts', methods=['POST'])
+def create_contract():
+    data = request.get_json() or {}
+    contract = Contract(
+        client_id=data.get('client_id'),
+        employee_id=data.get('employee_id'),
+        project_id=data.get('project_id'),
+        lead_id=data.get('lead_id'),
+        status_id=data.get('status_id'),
+        start_date=data.get('start_date'),
+        end_date=data.get('end_date'),
+        amount=data.get('amount'),
+    )
+    db.session.add(contract)
+    db.session.commit()
+    return jsonify({'id': contract.id}), 201
+
+
+@app.route('/contracts', methods=['GET'])
+def list_contracts():
+    contracts = Contract.query.all()
+    return jsonify([
+        {
+            'id': c.id,
+            'client': c.client.name if c.client else None,
+            'employee': c.employee.name if c.employee else None,
+            'project': c.project.name if c.project else None,
+            'lead': c.lead.name if c.lead else None,
+            'status': c.status.name if c.status else None,
+            'amount': str(c.amount) if c.amount else None,
+        }
+        for c in contracts
+    ])
+
+
+@app.route('/contracts/<int:contract_id>', methods=['GET', 'PUT', 'DELETE'])
+def handle_contract(contract_id):
+    contract = Contract.query.get_or_404(contract_id)
+    if request.method == 'GET':
+        return jsonify({
+            'id': contract.id,
+            'client_id': contract.client_id,
+            'employee_id': contract.employee_id,
+            'project_id': contract.project_id,
+            'lead_id': contract.lead_id,
+            'status_id': contract.status_id,
+            'start_date': contract.start_date.isoformat() if contract.start_date else None,
+            'end_date': contract.end_date.isoformat() if contract.end_date else None,
+            'amount': str(contract.amount) if contract.amount else None,
+        })
+    elif request.method == 'PUT':
+        data = request.get_json() or {}
+        for field in [
+            'client_id', 'employee_id', 'project_id', 'lead_id',
+            'status_id', 'start_date', 'end_date', 'amount'
+        ]:
+            if field in data:
+                setattr(contract, field, data[field])
+        db.session.commit()
+        return jsonify({'id': contract.id})
+    else:
+        db.session.delete(contract)
+        db.session.commit()
+        return '', 204
+
+
+@app.route('/tasks', methods=['POST'])
+def create_task():
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'Invalid input'}), 400
+    task = Task(
+        name=name,
+        due_date=data.get('due_date'),
+        completed=data.get('completed', False),
+        contract_id=data.get('contract_id'),
+    )
+    db.session.add(task)
+    db.session.commit()
+    sync_task_to_google(task)
+    return jsonify({'id': task.id}), 201
+
+
+@app.route('/tasks', methods=['GET'])
+def list_tasks():
+    tasks = Task.query.all()
+    return jsonify([
+        {
+            'id': t.id,
+            'name': t.name,
+            'completed': t.completed,
+            'due_date': t.due_date.isoformat() if t.due_date else None,
+            'contract_id': t.contract_id,
+        }
+        for t in tasks
+    ])
+
+
+@app.route('/tasks/<int:task_id>', methods=['GET', 'PUT', 'DELETE'])
+def handle_task(task_id):
+    task = Task.query.get_or_404(task_id)
+    if request.method == 'GET':
+        return jsonify({
+            'id': task.id,
+            'name': task.name,
+            'completed': task.completed,
+            'due_date': task.due_date.isoformat() if task.due_date else None,
+            'contract_id': task.contract_id,
+        })
+    elif request.method == 'PUT':
+        data = request.get_json() or {}
+        for field in ['name', 'completed', 'due_date', 'contract_id']:
+            if field in data:
+                setattr(task, field, data[field])
+        db.session.commit()
+        return jsonify({'id': task.id})
+    else:
+        db.session.delete(task)
+        db.session.commit()
+        return '', 204
+
 @app.route('/employees', methods=['GET'])
 def list_employees():
     employees = Employee.query.all()
@@ -225,5 +388,9 @@ if __name__ == '__main__':
         if Employee.query.count() == 0:
             for name in ['Stephanie Scher', 'Sable Murphy', 'Jennifer Stewart', 'Daniel Murphy']:
                 db.session.add(Employee(name=name))
+            db.session.commit()
+        if ContractStatus.query.count() == 0:
+            for name in ['Draft', 'Active', 'Completed']:
+                db.session.add(ContractStatus(name=name))
             db.session.commit()
     app.run(host='0.0.0.0', port=5000)

--- a/backend/models.py
+++ b/backend/models.py
@@ -98,3 +98,39 @@ class Lead(db.Model):
     contact_info = db.Column(db.String(256))
     stage_id = db.Column(db.Integer, db.ForeignKey('lead_stages.id'))
     stage = db.relationship('LeadStage')
+
+class ContractStatus(db.Model):
+    __tablename__ = 'contract_statuses'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True, nullable=False)
+
+
+class Contract(db.Model):
+    __tablename__ = 'contracts'
+    id = db.Column(db.Integer, primary_key=True)
+    client_id = db.Column(db.Integer, db.ForeignKey('clients.id'))
+    employee_id = db.Column(db.Integer, db.ForeignKey('employees.id'))
+    project_id = db.Column(db.Integer, db.ForeignKey('projects.id'))
+    lead_id = db.Column(db.Integer, db.ForeignKey('leads.id'))
+    status_id = db.Column(db.Integer, db.ForeignKey('contract_statuses.id'))
+    start_date = db.Column(db.Date)
+    end_date = db.Column(db.Date)
+    amount = db.Column(db.Numeric(10,2))
+
+    client = db.relationship('Client')
+    employee = db.relationship('Employee')
+    project = db.relationship('Project')
+    lead = db.relationship('Lead')
+    status = db.relationship('ContractStatus')
+
+
+class Task(db.Model):
+    __tablename__ = 'tasks'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)
+    due_date = db.Column(db.Date)
+    completed = db.Column(db.Boolean, default=False)
+    contract_id = db.Column(db.Integer, db.ForeignKey('contracts.id'))
+    google_task_id = db.Column(db.String(128))
+
+    contract = db.relationship('Contract')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ Flask-HTTPAuth==4.7.0
 psycopg2-binary==2.9.6
 pytest==7.4.0
 Flask-Cors==6.0.1
+google-api-python-client==2.114.0

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -4,7 +4,7 @@ os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 import werkzeug
 if not hasattr(werkzeug, '__version__'):
     werkzeug.__version__ = '0'
-from backend.app import app, db, Employee, LeadStage
+from backend.app import app, db, Employee, LeadStage, ContractStatus
 
 
 def setup_function(function):
@@ -15,6 +15,8 @@ def setup_function(function):
             db.session.add(LeadStage(name=name))
         for name in ['Stephanie Scher', 'Sable Murphy', 'Jennifer Stewart', 'Daniel Murphy']:
             db.session.add(Employee(name=name))
+        for name in ['Draft', 'Active', 'Completed']:
+            db.session.add(ContractStatus(name=name))
         db.session.commit()
 
 
@@ -46,3 +48,29 @@ def test_vendor_client_product_flow():
         rv = client.get('/leadstages')
         assert rv.status_code == 200
         assert len(rv.get_json()) == 4
+
+
+def test_contract_and_task_flow():
+    with app.app_context():
+        client = app.test_client()
+
+        rv = client.post('/clients', json={'name': 'ClientA'})
+        client_id = rv.get_json()['id']
+
+        rv = client.post('/projects', json={'name': 'Proj'})
+        project_id = rv.get_json()['id']
+
+        rv = client.post('/contracts', json={'client_id': client_id, 'project_id': project_id, 'status_id': 1})
+        assert rv.status_code == 201
+        contract_id = rv.get_json()['id']
+
+        rv = client.get('/contracts')
+        assert rv.status_code == 200
+        assert len(rv.get_json()) == 1
+
+        rv = client.post('/tasks', json={'name': 'Task1', 'contract_id': contract_id})
+        assert rv.status_code == 201
+
+        rv = client.get('/tasks')
+        assert rv.status_code == 200
+        assert len(rv.get_json()) == 1

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,5 +1,5 @@
 import sys, os; sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-from backend.models import Product
+from backend.models import Product, ContractStatus, Contract, Task
 
 def test_product_to_dict():
     p = Product(id=1, sku='SKU123', name='Chair', price=99.99)
@@ -11,3 +11,11 @@ def test_product_to_dict():
         'vendor': None
     }
     assert p.to_dict() == expected
+
+
+def test_contract_and_task_models():
+    status = ContractStatus(id=1, name='Draft')
+    contract = Contract(id=2, client_id=1, status=status)
+    task = Task(id=3, name='Test', contract=contract)
+    assert contract.status.name == 'Draft'
+    assert task.contract is contract

--- a/frontend/components/Nav.js
+++ b/frontend/components/Nav.js
@@ -9,6 +9,7 @@ export default function Nav() {
       <Link href="/clients">Clients</Link>
       <Link href="/projects">Projects</Link>
       <Link href="/leads">Leads</Link>
+      <Link href="/contracts">Contracts</Link>
     </nav>
   );
 }

--- a/frontend/pages/contracts.js
+++ b/frontend/pages/contracts.js
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+
+const API = 'http://localhost:5000';
+
+export default function Contracts() {
+  const [contracts, setContracts] = useState([]);
+  const [clients, setClients] = useState([]);
+  const [employees, setEmployees] = useState([]);
+  const [projects, setProjects] = useState([]);
+  const [statuses, setStatuses] = useState([]);
+  const [clientId, setClientId] = useState('');
+  const [employeeId, setEmployeeId] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [statusId, setStatusId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [message, setMessage] = useState('');
+
+  const fetchContracts = async () => {
+    const res = await fetch(`${API}/contracts`);
+    setContracts(await res.json());
+  };
+  const fetchClients = async () => {
+    const res = await fetch(`${API}/clients`);
+    setClients(await res.json());
+  };
+  const fetchEmployees = async () => {
+    const res = await fetch(`${API}/employees`);
+    setEmployees(await res.json());
+  };
+  const fetchProjects = async () => {
+    const res = await fetch(`${API}/projects`);
+    setProjects(await res.json());
+  };
+  const fetchStatuses = async () => {
+    const res = await fetch(`${API}/contractstatuses`);
+    setStatuses(await res.json());
+  };
+
+  useEffect(() => { fetchContracts(); fetchClients(); fetchEmployees(); fetchProjects(); fetchStatuses(); }, []);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const res = await fetch(`${API}/contracts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId || null,
+        employee_id: employeeId || null,
+        project_id: projectId || null,
+        status_id: statusId || null,
+        amount
+      })
+    });
+    if (res.ok) {
+      setMessage('Added contract');
+      fetchContracts();
+    } else {
+      setMessage('Error adding contract');
+    }
+    setClientId('');
+    setEmployeeId('');
+    setProjectId('');
+    setStatusId('');
+    setAmount('');
+  };
+
+  return (
+    <main>
+      <h1>Contracts</h1>
+      {message && <p className="message">{message}</p>}
+      <form onSubmit={submit} className="form">
+        <select value={clientId} onChange={e => setClientId(e.target.value)}>
+          <option value="">Client</option>
+          {clients.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+        </select>
+        <select value={employeeId} onChange={e => setEmployeeId(e.target.value)}>
+          <option value="">Employee</option>
+          {employees.map(emp => <option key={emp.id} value={emp.id}>{emp.name}</option>)}
+        </select>
+        <select value={projectId} onChange={e => setProjectId(e.target.value)}>
+          <option value="">Project</option>
+          {projects.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+        </select>
+        <select value={statusId} onChange={e => setStatusId(e.target.value)}>
+          <option value="">Status</option>
+          {statuses.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+        <input value={amount} onChange={e => setAmount(e.target.value)} placeholder="Amount" />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {contracts.map(c => (
+          <li key={c.id}>{c.project || 'No Project'} - {c.client || 'No Client'} - {c.status}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- define ContractStatus, Contract, and Task models
- integrate Google Tasks sync helper
- add CRUD routes for contract and task management
- seed contract statuses on app start
- show Contracts page in Next.js frontend and link in nav
- add google-api-python-client dependency
- extend tests for new models and API endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a0ce4cdc832fa4610a352ab30563