### PR TITLE
Apply currency formatting for price and contract amount

### DIFF
--- a/backend/tests/test_formatting.py
+++ b/backend/tests/test_formatting.py
@@ -1,0 +1,7 @@
+import subprocess
+
+
+def test_js_currency_formatting():
+    js_code = "console.log(new Intl.NumberFormat('en-US', {style:'currency', currency:'USD'}).format(1234.56))"
+    output = subprocess.check_output(['node', '-e', js_code], text=True).strip()
+    assert output == '$1,234.56'

--- a/frontend/pages/contracts.js
+++ b/frontend/pages/contracts.js
@@ -65,11 +65,24 @@ export default function Contracts() {
     setAmount('');
   };
 
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  });
+
   const columns = [
     { field: 'project', headerName: 'Project', flex: 1 },
     { field: 'client', headerName: 'Client', flex: 1 },
     { field: 'status', headerName: 'Status', flex: 1 },
-    { field: 'amount', headerName: 'Amount', flex: 1 },
+    {
+      field: 'amount',
+      headerName: 'Amount',
+      flex: 1,
+      valueFormatter: ({ value }) =>
+        value === undefined || value === null || value === ''
+          ? ''
+          : currencyFormatter.format(Number(value))
+    },
   ];
 
   return (

--- a/frontend/pages/products.js
+++ b/frontend/pages/products.js
@@ -45,10 +45,23 @@ export default function Products() {
     fetchProducts();
   };
 
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  });
+
   const columns = [
     { field: 'sku', headerName: 'SKU', flex: 1 },
     { field: 'name', headerName: 'Name', flex: 1 },
-    { field: 'price', headerName: 'Price', flex: 1 },
+    {
+      field: 'price',
+      headerName: 'Price',
+      flex: 1,
+      valueFormatter: ({ value }) =>
+        value === undefined || value === null || value === ''
+          ? ''
+          : currencyFormatter.format(Number(value))
+    },
     { field: 'vendor', headerName: 'Vendor', flex: 1 },
   ];
 


### PR DESCRIPTION
## Summary
- show prices and contract amounts in USD
- add a Node-based test showing number formatting

## Testing
- `cd backend && pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865af258da4832fb1006515eb5559e5