### PR TITLE
Add DataGrid edit/delete actions

### DIFF
--- a/frontend/__tests__/api.test.js
+++ b/frontend/__tests__/api.test.js
@@ -1,0 +1,17 @@
+const { putData, deleteData } = require('../lib/api.js');
+
+global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+
+afterEach(() => {
+  fetch.mockClear();
+});
+
+test('putData uses PUT method', async () => {
+  await putData('/vendors/1', { name: 'V' });
+  expect(fetch).toHaveBeenCalledWith('/vendors/1', expect.objectContaining({ method: 'PUT' }));
+});
+
+test('deleteData uses DELETE method', async () => {
+  await deleteData('/vendors/1');
+  expect(fetch).toHaveBeenCalledWith('/vendors/1', expect.objectContaining({ method: 'DELETE' }));
+});

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,0 +1,10 @@
+const putData = (url, data) =>
+  fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+
+const deleteData = (url) => fetch(url, { method: 'DELETE' });
+
+module.exports = { putData, deleteData };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,15 +4,23 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.2.0",
+    "@mui/icons-material": "^5.15.0",
     "@mui/x-data-grid": "^8.6.0",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/frontend/pages/contracts.js
+++ b/frontend/pages/contracts.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridRowModes,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
@@ -15,10 +24,31 @@ export default function Contracts() {
   const [statusId, setStatusId] = useState('');
   const [amount, setAmount] = useState('');
   const [message, setMessage] = useState('');
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const fetchContracts = async () => {
     const res = await fetch(`${API}/contracts`);
     setContracts(await res.json());
+  };
+
+  const processRowUpdate = async (newRow) => {
+    await putData(`${API}/contracts/${newRow.id}`, newRow);
+    fetchContracts();
+    return newRow;
+  };
+
+  const handleEditClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (id) => async () => {
+    if (!window.confirm('Delete this contract?')) return;
+    await deleteData(`${API}/contracts/${id}`);
+    fetchContracts();
   };
   const fetchClients = async () => {
     const res = await fetch(`${API}/clients`);
@@ -27,6 +57,14 @@ export default function Contracts() {
   const fetchEmployees = async () => {
     const res = await fetch(`${API}/employees`);
     setEmployees(await res.json());
+  };
+
+  const handleRowEditStart = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (params, event) => {
+    event.defaultMuiPrevented = true;
   };
   const fetchProjects = async () => {
     const res = await fetch(`${API}/projects`);
@@ -83,6 +121,36 @@ export default function Contracts() {
           ? ''
           : currencyFormatter.format(Number(value))
     },
+    {
+      field: 'actions',
+      type: 'actions',
+      getActions: (params) => {
+        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+        return inEdit
+          ? [
+              <GridActionsCellItem
+                key="save"
+                icon={<SaveIcon />}
+                label="Save"
+                onClick={handleSaveClick(params.id)}
+              />,
+            ]
+          : [
+              <GridActionsCellItem
+                key="edit"
+                icon={<EditIcon />}
+                label="Edit"
+                onClick={handleEditClick(params.id)}
+              />,
+              <GridActionsCellItem
+                key="delete"
+                icon={<DeleteIcon />}
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+              />,
+            ];
+      },
+    },
   ];
 
   return (
@@ -115,6 +183,12 @@ export default function Contracts() {
           rows={contracts}
           columns={columns}
           getRowId={(row) => row.id}
+          editMode="row"
+          processRowUpdate={processRowUpdate}
+          onRowEditStart={handleRowEditStart}
+          onRowEditStop={handleRowEditStop}
+          rowModesModel={rowModesModel}
+          onRowModesModelChange={setRowModesModel}
           disableRowSelectionOnClick
         />
       </div>

--- a/frontend/pages/leads.js
+++ b/frontend/pages/leads.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridRowModes,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
@@ -10,6 +19,7 @@ export default function Leads() {
   const [contact, setContact] = useState('');
   const [stageId, setStageId] = useState('');
   const [message, setMessage] = useState('');
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const fetchLeads = async () => {
     const res = await fetch(`${API}/leads`);
@@ -17,10 +27,38 @@ export default function Leads() {
     setLeads(data);
   };
 
+  const processRowUpdate = async (newRow) => {
+    await putData(`${API}/leads/${newRow.id}`, newRow);
+    fetchLeads();
+    return newRow;
+  };
+
+  const handleEditClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (id) => async () => {
+    if (!window.confirm('Delete this lead?')) return;
+    await deleteData(`${API}/leads/${id}`);
+    fetchLeads();
+  };
+
   const fetchStages = async () => {
     const res = await fetch(`${API}/leadstages`);
     const data = await res.json();
     setStages(data);
+  };
+
+  const handleRowEditStart = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (params, event) => {
+    event.defaultMuiPrevented = true;
   };
 
   useEffect(() => { fetchLeads(); fetchStages(); }, []);
@@ -46,6 +84,36 @@ export default function Leads() {
   const columns = [
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'stage', headerName: 'Stage', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      getActions: (params) => {
+        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+        return inEdit
+          ? [
+              <GridActionsCellItem
+                key="save"
+                icon={<SaveIcon />}
+                label="Save"
+                onClick={handleSaveClick(params.id)}
+              />,
+            ]
+          : [
+              <GridActionsCellItem
+                key="edit"
+                icon={<EditIcon />}
+                label="Edit"
+                onClick={handleEditClick(params.id)}
+              />,
+              <GridActionsCellItem
+                key="delete"
+                icon={<DeleteIcon />}
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+              />,
+            ];
+      },
+    },
   ];
 
   return (
@@ -67,6 +135,12 @@ export default function Leads() {
           rows={leads}
           columns={columns}
           getRowId={(row) => row.id}
+          editMode="row"
+          processRowUpdate={processRowUpdate}
+          onRowEditStart={handleRowEditStart}
+          onRowEditStop={handleRowEditStop}
+          rowModesModel={rowModesModel}
+          onRowModesModelChange={setRowModesModel}
           disableRowSelectionOnClick
         />
       </div>

--- a/frontend/pages/products.js
+++ b/frontend/pages/products.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridRowModes,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
@@ -11,6 +20,7 @@ export default function Products() {
   const [price, setPrice] = useState('');
   const [vendorId, setVendorId] = useState('');
   const [message, setMessage] = useState('');
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const fetchProducts = async () => {
     const res = await fetch(`${API}/products`);
@@ -18,10 +28,38 @@ export default function Products() {
     setProducts(data);
   };
 
+  const processRowUpdate = async (newRow) => {
+    await putData(`${API}/products/${newRow.id}`, newRow);
+    fetchProducts();
+    return newRow;
+  };
+
+  const handleEditClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (id) => async () => {
+    if (!window.confirm('Delete this product?')) return;
+    await deleteData(`${API}/products/${id}`);
+    fetchProducts();
+  };
+
   const fetchVendors = async () => {
     const res = await fetch(`${API}/vendors`);
     const data = await res.json();
     setVendors(data);
+  };
+
+  const handleRowEditStart = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (params, event) => {
+    event.defaultMuiPrevented = true;
   };
 
   useEffect(() => { fetchProducts(); fetchVendors(); }, []);
@@ -63,6 +101,36 @@ export default function Products() {
           : currencyFormatter.format(Number(value))
     },
     { field: 'vendor', headerName: 'Vendor', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      getActions: (params) => {
+        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+        return inEdit
+          ? [
+              <GridActionsCellItem
+                key="save"
+                icon={<SaveIcon />}
+                label="Save"
+                onClick={handleSaveClick(params.id)}
+              />,
+            ]
+          : [
+              <GridActionsCellItem
+                key="edit"
+                icon={<EditIcon />}
+                label="Edit"
+                onClick={handleEditClick(params.id)}
+              />,
+              <GridActionsCellItem
+                key="delete"
+                icon={<DeleteIcon />}
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+              />,
+            ];
+      },
+    },
   ];
 
   return (
@@ -85,6 +153,12 @@ export default function Products() {
           rows={products}
           columns={columns}
           getRowId={(row) => row.id}
+          editMode="row"
+          processRowUpdate={processRowUpdate}
+          onRowEditStart={handleRowEditStart}
+          onRowEditStop={handleRowEditStop}
+          rowModesModel={rowModesModel}
+          onRowModesModelChange={setRowModesModel}
           disableRowSelectionOnClick
         />
       </div>

--- a/frontend/pages/projects.js
+++ b/frontend/pages/projects.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridRowModes,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
@@ -12,6 +21,7 @@ export default function Projects() {
   const [clientId, setClientId] = useState('');
   const [productIds, setProductIds] = useState([]);
   const [message, setMessage] = useState('');
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const fetchProjects = async () => {
     const res = await fetch(`${API}/projects`);
@@ -19,10 +29,38 @@ export default function Projects() {
     setProjects(data);
   };
 
+  const processRowUpdate = async (newRow) => {
+    await putData(`${API}/projects/${newRow.id}`, newRow);
+    fetchProjects();
+    return newRow;
+  };
+
+  const handleEditClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (id) => async () => {
+    if (!window.confirm('Delete this project?')) return;
+    await deleteData(`${API}/projects/${id}`);
+    fetchProjects();
+  };
+
   const fetchClients = async () => {
     const res = await fetch(`${API}/clients`);
     const data = await res.json();
     setClients(data);
+  };
+
+  const handleRowEditStart = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (params, event) => {
+    event.defaultMuiPrevented = true;
   };
 
   const fetchProducts = async () => {
@@ -65,6 +103,36 @@ export default function Projects() {
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'start_date', headerName: 'Start Date', flex: 1 },
     { field: 'client', headerName: 'Client', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      getActions: (params) => {
+        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+        return inEdit
+          ? [
+              <GridActionsCellItem
+                key="save"
+                icon={<SaveIcon />}
+                label="Save"
+                onClick={handleSaveClick(params.id)}
+              />,
+            ]
+          : [
+              <GridActionsCellItem
+                key="edit"
+                icon={<EditIcon />}
+                label="Edit"
+                onClick={handleEditClick(params.id)}
+              />,
+              <GridActionsCellItem
+                key="delete"
+                icon={<DeleteIcon />}
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+              />,
+            ];
+      },
+    },
   ];
 
   return (
@@ -99,6 +167,12 @@ export default function Projects() {
           rows={projects}
           columns={columns}
           getRowId={(row) => row.id}
+          editMode="row"
+          processRowUpdate={processRowUpdate}
+          onRowEditStart={handleRowEditStart}
+          onRowEditStop={handleRowEditStop}
+          rowModesModel={rowModesModel}
+          onRowModesModelChange={setRowModesModel}
           disableRowSelectionOnClick
         />
       </div>

--- a/frontend/pages/vendors.js
+++ b/frontend/pages/vendors.js
@@ -1,5 +1,14 @@
 import { useState, useEffect } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  GridActionsCellItem,
+  GridRowModes,
+  GridRowModesModel,
+} from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import SaveIcon from '@mui/icons-material/Save';
+import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
@@ -8,6 +17,7 @@ export default function Vendors() {
   const [name, setName] = useState('');
   const [contact, setContact] = useState('');
   const [message, setMessage] = useState('');
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const fetchVendors = async () => {
     const res = await fetch(`${API}/vendors`);
@@ -15,7 +25,35 @@ export default function Vendors() {
     setVendors(data);
   };
 
+  const processRowUpdate = async (newRow) => {
+    await putData(`${API}/vendors/${newRow.id}`, newRow);
+    fetchVendors();
+    return newRow;
+  };
+
+  const handleEditClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
+  };
+
+  const handleSaveClick = (id) => () => {
+    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
+  };
+
+  const handleDeleteClick = (id) => async () => {
+    if (!window.confirm('Delete this vendor?')) return;
+    await deleteData(`${API}/vendors/${id}`);
+    fetchVendors();
+  };
+
   useEffect(() => { fetchVendors(); }, []);
+
+  const handleRowEditStart = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (params, event) => {
+    event.defaultMuiPrevented = true;
+  };
 
   const submit = async (e) => {
     e.preventDefault();
@@ -37,6 +75,36 @@ export default function Vendors() {
   const columns = [
     { field: 'name', headerName: 'Name', flex: 1 },
     { field: 'contact_info', headerName: 'Contact Info', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      getActions: (params) => {
+        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
+        return inEdit
+          ? [
+              <GridActionsCellItem
+                key="save"
+                icon={<SaveIcon />}
+                label="Save"
+                onClick={handleSaveClick(params.id)}
+              />,
+            ]
+          : [
+              <GridActionsCellItem
+                key="edit"
+                icon={<EditIcon />}
+                label="Edit"
+                onClick={handleEditClick(params.id)}
+              />,
+              <GridActionsCellItem
+                key="delete"
+                icon={<DeleteIcon />}
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+              />,
+            ];
+      },
+    },
   ];
 
   return (
@@ -54,6 +122,12 @@ export default function Vendors() {
           rows={vendors}
           columns={columns}
           getRowId={(row) => row.id}
+          editMode="row"
+          processRowUpdate={processRowUpdate}
+          onRowEditStart={handleRowEditStart}
+          onRowEditStop={handleRowEditStop}
+          rowModesModel={rowModesModel}
+          onRowModesModelChange={setRowModesModel}
           disableRowSelectionOnClick
         />
       </div>


### PR DESCRIPTION
## Summary
- add shared API helpers for PUT and DELETE calls
- update DataGrid pages to include edit/delete actions
- confirm before deleting and refresh data after edits
- add basic Jest unit tests for API helpers

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError for flask_sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6865af24a804832fbffd20488f29fd1a