### PR TITLE
Fix currency formatter for invalid values

### DIFF
--- a/backend/tests/test_formatting.py
+++ b/backend/tests/test_formatting.py
@@ -5,3 +5,13 @@ def test_js_currency_formatting():
     js_code = "console.log(new Intl.NumberFormat('en-US', {style:'currency', currency:'USD'}).format(1234.56))"
     output = subprocess.check_output(['node', '-e', js_code], text=True).strip()
     assert output == '$1,234.56'
+
+
+def test_js_value_formatter_handles_none_string():
+    js_code = (
+        "const f=v=>{if(v===undefined||v===null||v===''||!Number.isFinite(Number(v)))" \
+        " return '';return new Intl.NumberFormat('en-US',{style:'currency',currency:'USD'}).format(Number(v));};" \
+        "console.log(f('None'));"
+    )
+    output = subprocess.check_output(['node', '-e', js_code], text=True).strip()
+    assert output == ''

--- a/frontend/pages/contracts.js
+++ b/frontend/pages/contracts.js
@@ -117,7 +117,8 @@ export default function Contracts() {
       headerName: 'Amount',
       flex: 1,
       valueFormatter: ({ value }) =>
-        value === undefined || value === null || value === ''
+        value === undefined || value === null || value === '' ||
+        !Number.isFinite(Number(value))
           ? ''
           : currencyFormatter.format(Number(value))
     },

--- a/frontend/pages/products.js
+++ b/frontend/pages/products.js
@@ -96,7 +96,8 @@ export default function Products() {
       headerName: 'Price',
       flex: 1,
       valueFormatter: ({ value }) =>
-        value === undefined || value === null || value === ''
+        value === undefined || value === null || value === '' ||
+        !Number.isFinite(Number(value))
           ? ''
           : currencyFormatter.format(Number(value))
     },


### PR DESCRIPTION
## Summary
- ensure `valueFormatter` handles non-numeric values on product and contract lists
- test JS formatter correctly returns an empty string for `'None'`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b2a1d910832f873d966753ba2fb6