### PR TITLE
Add vendor contact info and popup editor

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -92,7 +92,23 @@ def create_vendor():
     name = data.get('name')
     if not name:
         return jsonify({'error': 'Invalid input'}), 400
-    vendor = Vendor(name=name, contact_info=data.get('contact_info'))
+    vendor = Vendor(
+        name=name,
+        contact_info=data.get('contact_info'),
+        first_name=data.get('first_name'),
+        last_name=data.get('last_name'),
+        primary_email=data.get('primary_email'),
+        secondary_email=data.get('secondary_email'),
+        primary_phone=data.get('primary_phone'),
+        secondary_phone=data.get('secondary_phone'),
+        description=data.get('description'),
+        address1=data.get('address1'),
+        address2=data.get('address2'),
+        city=data.get('city'),
+        state=data.get('state'),
+        zip_code=data.get('zip_code'),
+        tax_id=data.get('tax_id'),
+    )
     db.session.add(vendor)
     db.session.commit()
     return jsonify({'id': vendor.id}), 201
@@ -101,24 +117,21 @@ def create_vendor():
 @app.route('/vendors', methods=['GET'])
 def list_vendors():
     vendors = Vendor.query.all()
-    return jsonify([
-        {'id': v.id, 'name': v.name, 'contact_info': v.contact_info}
-        for v in vendors
-    ])
+    return jsonify([v.to_dict() for v in vendors])
 
 
 @app.route('/vendors/<int:vendor_id>', methods=['GET', 'PUT', 'DELETE'])
 def handle_vendor(vendor_id):
     vendor = Vendor.query.get_or_404(vendor_id)
     if request.method == 'GET':
-        return jsonify({
-            'id': vendor.id,
-            'name': vendor.name,
-            'contact_info': vendor.contact_info,
-        })
+        return jsonify(vendor.to_dict())
     elif request.method == 'PUT':
         data = request.get_json() or {}
-        for field in ['name', 'contact_info']:
+        for field in [
+            'name', 'contact_info', 'first_name', 'last_name', 'primary_email',
+            'secondary_email', 'primary_phone', 'secondary_phone', 'description',
+            'address1', 'address2', 'city', 'state', 'zip_code', 'tax_id'
+        ]:
             if field in data:
                 setattr(vendor, field, data[field])
         db.session.commit()

--- a/backend/models.py
+++ b/backend/models.py
@@ -22,6 +22,41 @@ class Vendor(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128), nullable=False)
     contact_info = db.Column(db.String(256))
+    first_name = db.Column(db.String(64))
+    last_name = db.Column(db.String(64))
+    primary_email = db.Column(db.String(128))
+    secondary_email = db.Column(db.String(128))
+    primary_phone = db.Column(db.String(32))
+    secondary_phone = db.Column(db.String(32))
+    description = db.Column(db.Text)
+    address1 = db.Column(db.String(128))
+    address2 = db.Column(db.String(128))
+    city = db.Column(db.String(64))
+    state = db.Column(db.String(32))
+    zip_code = db.Column(db.String(10))
+    tax_id = db.Column(db.String(64))
+    products = db.relationship('Product', back_populates='vendor')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'contact_info': self.contact_info,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
+            'primary_email': self.primary_email,
+            'secondary_email': self.secondary_email,
+            'primary_phone': self.primary_phone,
+            'secondary_phone': self.secondary_phone,
+            'description': self.description,
+            'address1': self.address1,
+            'address2': self.address2,
+            'city': self.city,
+            'state': self.state,
+            'zip_code': self.zip_code,
+            'tax_id': self.tax_id,
+            'products': [p.name for p in self.products]
+        }
 
 class Product(db.Model):
     __tablename__ = 'products'
@@ -30,7 +65,7 @@ class Product(db.Model):
     name = db.Column(db.String(128), nullable=False)
     price = db.Column(db.Numeric(10,2))
     vendor_id = db.Column(db.Integer, db.ForeignKey('vendors.id'))
-    vendor = db.relationship('Vendor')
+    vendor = db.relationship('Vendor', back_populates='products')
 
     def to_dict(self):
         return {

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -23,7 +23,13 @@ def setup_function(function):
 def test_vendor_client_product_flow():
     with app.app_context():
         client = app.test_client()
-        rv = client.post('/vendors', json={'name': 'Vendor1'})
+        rv = client.post('/vendors', json={
+            'name': 'Vendor1',
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'primary_email': 'john@example.com',
+            'primary_phone': '111-2222'
+        })
         assert rv.status_code == 201
         vendor_id = rv.get_json()['id']
 
@@ -35,7 +41,9 @@ def test_vendor_client_product_flow():
 
         rv = client.get('/vendors')
         assert rv.status_code == 200
-        assert len(rv.get_json()) == 1
+        vendors = rv.get_json()
+        assert len(vendors) == 1
+        assert vendors[0]['first_name'] == 'John'
 
         rv = client.get('/products')
         assert rv.status_code == 200
@@ -81,14 +89,14 @@ def test_crud_endpoints():
         client = app.test_client()
 
         # Vendor CRUD
-        rv = client.post('/vendors', json={'name': 'V1'})
+        rv = client.post('/vendors', json={'name': 'V1', 'primary_email': 'a@b.c'})
         vid = rv.get_json()['id']
         rv = client.get(f'/vendors/{vid}')
-        assert rv.get_json()['name'] == 'V1'
-        rv = client.put(f'/vendors/{vid}', json={'name': 'V2'})
+        assert rv.get_json()['primary_email'] == 'a@b.c'
+        rv = client.put(f'/vendors/{vid}', json={'primary_email': 'd@e.f'})
         assert rv.status_code == 200
         rv = client.get(f'/vendors/{vid}')
-        assert rv.get_json()['name'] == 'V2'
+        assert rv.get_json()['primary_email'] == 'd@e.f'
         rv = client.delete(f'/vendors/{vid}')
         assert rv.status_code == 204
         assert client.get('/vendors').get_json() == []

--- a/frontend/pages/vendors.js
+++ b/frontend/pages/vendors.js
@@ -2,21 +2,27 @@ import { useState, useEffect } from 'react';
 import {
   DataGrid,
   GridActionsCellItem,
-  GridRowModes,
 } from '@mui/x-data-grid';
-import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
-import SaveIcon from '@mui/icons-material/Save';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from '@mui/material';
 import { putData, deleteData } from '../lib/api.js';
 
 const API = 'http://localhost:5000';
 
 export default function Vendors() {
   const [vendors, setVendors] = useState([]);
-  const [name, setName] = useState('');
-  const [contact, setContact] = useState('');
+  const [form, setForm] = useState({});
+  const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
-  const [rowModesModel, setRowModesModel] = useState({});
+
+  // fields for creating new vendor
+  const [newVendor, setNewVendor] = useState({ name: '', contact_info: '', first_name: '', last_name: '', primary_email: '', secondary_email: '', primary_phone: '', secondary_phone: '', description: '', address1: '', address2: '', city: '', state: '', zip_code: '', tax_id: '' });
 
   const fetchVendors = async () => {
     const res = await fetch(`${API}/vendors`);
@@ -24,19 +30,7 @@ export default function Vendors() {
     setVendors(data);
   };
 
-  const processRowUpdate = async (newRow) => {
-    await putData(`${API}/vendors/${newRow.id}`, newRow);
-    fetchVendors();
-    return newRow;
-  };
-
-  const handleEditClick = (id) => () => {
-    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } });
-  };
-
-  const handleSaveClick = (id) => () => {
-    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } });
-  };
+  useEffect(() => { fetchVendors(); }, []);
 
   const handleDeleteClick = (id) => async () => {
     if (!window.confirm('Delete this vendor?')) return;
@@ -44,14 +38,19 @@ export default function Vendors() {
     fetchVendors();
   };
 
-  useEffect(() => { fetchVendors(); }, []);
-
-  const handleRowEditStart = (params, event) => {
-    event.defaultMuiPrevented = true;
+  const handleRowClick = async (params) => {
+    const res = await fetch(`${API}/vendors/${params.row.id}`);
+    const data = await res.json();
+    setForm(data);
+    setOpen(true);
   };
 
-  const handleRowEditStop = (params, event) => {
-    event.defaultMuiPrevented = true;
+  const closeDialog = () => { setOpen(false); };
+
+  const saveDialog = async () => {
+    await putData(`${API}/vendors/${form.id}`, form);
+    setOpen(false);
+    fetchVendors();
   };
 
   const submit = async (e) => {
@@ -59,50 +58,32 @@ export default function Vendors() {
     const res = await fetch(`${API}/vendors`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, contact_info: contact })
+      body: JSON.stringify(newVendor)
     });
     if (res.ok) {
-      setMessage(`Added vendor: ${name}`);
+      setMessage(`Added vendor: ${newVendor.name}`);
+      setNewVendor({ name: '', contact_info: '', first_name: '', last_name: '', primary_email: '', secondary_email: '', primary_phone: '', secondary_phone: '', description: '', address1: '', address2: '', city: '', state: '', zip_code: '', tax_id: '' });
+      fetchVendors();
     } else {
       setMessage('Error adding vendor');
     }
-    setName('');
-    setContact('');
-    fetchVendors();
   };
 
   const columns = [
-    { field: 'name', headerName: 'Name', flex: 1 },
-    { field: 'contact_info', headerName: 'Contact Info', flex: 1 },
+    { field: 'name', headerName: 'Vendor', flex: 1 },
+    { field: 'primary_email', headerName: 'Primary Email', flex: 1 },
+    { field: 'primary_phone', headerName: 'Primary Phone', flex: 1 },
     {
       field: 'actions',
       type: 'actions',
-      getActions: (params) => {
-        const inEdit = rowModesModel[params.id]?.mode === GridRowModes.Edit;
-        return inEdit
-          ? [
-              <GridActionsCellItem
-                key="save"
-                icon={<SaveIcon />}
-                label="Save"
-                onClick={handleSaveClick(params.id)}
-              />,
-            ]
-          : [
-              <GridActionsCellItem
-                key="edit"
-                icon={<EditIcon />}
-                label="Edit"
-                onClick={handleEditClick(params.id)}
-              />,
-              <GridActionsCellItem
-                key="delete"
-                icon={<DeleteIcon />}
-                label="Delete"
-                onClick={handleDeleteClick(params.id)}
-              />,
-            ];
-      },
+      getActions: (params) => [
+        <GridActionsCellItem
+          key="delete"
+          icon={<DeleteIcon />}
+          label="Delete"
+          onClick={handleDeleteClick(params.id)}
+        />,
+      ],
     },
   ];
 
@@ -110,9 +91,22 @@ export default function Vendors() {
     <main>
       <h1>Vendors</h1>
       {message && <p className="message">{message}</p>}
-      <form onSubmit={submit} className="form">
-        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" required />
-        <input value={contact} onChange={e => setContact(e.target.value)} placeholder="Contact Info" />
+      <form onSubmit={submit} className="form" style={{flexWrap:'wrap'}}>
+        <input value={newVendor.name} onChange={e => setNewVendor({ ...newVendor, name: e.target.value })} placeholder="Name" required />
+        <input value={newVendor.first_name} onChange={e => setNewVendor({ ...newVendor, first_name: e.target.value })} placeholder="First Name" />
+        <input value={newVendor.last_name} onChange={e => setNewVendor({ ...newVendor, last_name: e.target.value })} placeholder="Last Name" />
+        <input value={newVendor.primary_email} onChange={e => setNewVendor({ ...newVendor, primary_email: e.target.value })} placeholder="Primary Email" />
+        <input value={newVendor.secondary_email} onChange={e => setNewVendor({ ...newVendor, secondary_email: e.target.value })} placeholder="Secondary Email" />
+        <input value={newVendor.primary_phone} onChange={e => setNewVendor({ ...newVendor, primary_phone: e.target.value })} placeholder="Primary Phone" />
+        <input value={newVendor.secondary_phone} onChange={e => setNewVendor({ ...newVendor, secondary_phone: e.target.value })} placeholder="Secondary Phone" />
+        <input value={newVendor.description} onChange={e => setNewVendor({ ...newVendor, description: e.target.value })} placeholder="Description" />
+        <input value={newVendor.address1} onChange={e => setNewVendor({ ...newVendor, address1: e.target.value })} placeholder="Address" />
+        <input value={newVendor.address2} onChange={e => setNewVendor({ ...newVendor, address2: e.target.value })} placeholder="Address 2" />
+        <input value={newVendor.city} onChange={e => setNewVendor({ ...newVendor, city: e.target.value })} placeholder="City" />
+        <input value={newVendor.state} onChange={e => setNewVendor({ ...newVendor, state: e.target.value })} placeholder="State" />
+        <input value={newVendor.zip_code} onChange={e => setNewVendor({ ...newVendor, zip_code: e.target.value })} placeholder="Zip" />
+        <input value={newVendor.tax_id} onChange={e => setNewVendor({ ...newVendor, tax_id: e.target.value })} placeholder="Tax ID" />
+        <input value={newVendor.contact_info} onChange={e => setNewVendor({ ...newVendor, contact_info: e.target.value })} placeholder="Other Contact" />
         <button type="submit">Add</button>
       </form>
       <div style={{ width: '100%' }}>
@@ -121,15 +115,42 @@ export default function Vendors() {
           rows={vendors}
           columns={columns}
           getRowId={(row) => row.id}
-          editMode="row"
-          processRowUpdate={processRowUpdate}
-          onRowEditStart={handleRowEditStart}
-          onRowEditStop={handleRowEditStop}
-          rowModesModel={rowModesModel}
-          onRowModesModelChange={setRowModesModel}
+          onRowClick={handleRowClick}
           disableRowSelectionOnClick
         />
       </div>
+
+      {open && (
+        <Dialog open={open} onClose={closeDialog} fullWidth>
+          <DialogTitle>Edit Vendor</DialogTitle>
+          <DialogContent style={{display:'flex',flexDirection:'column',gap:'0.5rem'}}>
+            <input value={form.name || ''} onChange={e => setForm({...form,name:e.target.value})} placeholder="Name" />
+            <input value={form.first_name || ''} onChange={e => setForm({...form,first_name:e.target.value})} placeholder="First Name" />
+            <input value={form.last_name || ''} onChange={e => setForm({...form,last_name:e.target.value})} placeholder="Last Name" />
+            <input value={form.primary_email || ''} onChange={e => setForm({...form,primary_email:e.target.value})} placeholder="Primary Email" />
+            <input value={form.secondary_email || ''} onChange={e => setForm({...form,secondary_email:e.target.value})} placeholder="Secondary Email" />
+            <input value={form.primary_phone || ''} onChange={e => setForm({...form,primary_phone:e.target.value})} placeholder="Primary Phone" />
+            <input value={form.secondary_phone || ''} onChange={e => setForm({...form,secondary_phone:e.target.value})} placeholder="Secondary Phone" />
+            <input value={form.description || ''} onChange={e => setForm({...form,description:e.target.value})} placeholder="Description" />
+            <input value={form.address1 || ''} onChange={e => setForm({...form,address1:e.target.value})} placeholder="Address" />
+            <input value={form.address2 || ''} onChange={e => setForm({...form,address2:e.target.value})} placeholder="Address 2" />
+            <input value={form.city || ''} onChange={e => setForm({...form,city:e.target.value})} placeholder="City" />
+            <input value={form.state || ''} onChange={e => setForm({...form,state:e.target.value})} placeholder="State" />
+            <input value={form.zip_code || ''} onChange={e => setForm({...form,zip_code:e.target.value})} placeholder="Zip" />
+            <input value={form.tax_id || ''} onChange={e => setForm({...form,tax_id:e.target.value})} placeholder="Tax ID" />
+            <div>
+              <strong>Products:</strong>
+              <ul>
+                {(form.products || []).map((p,i) => <li key={i}>{p}</li>)}
+              </ul>
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={closeDialog}>Cancel</Button>
+            <Button onClick={saveDialog}>Save</Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- extend vendor model with contact details and address fields
- provide vendor list endpoints with full vendor data
- update vendor CRUD tests accordingly
- add editing dialog on vendor page

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686684cc463c832f958f98d4ac82f640